### PR TITLE
Change Dense weights and dW to a tensor shape

### DIFF
--- a/convolutional_neural_network.cpp
+++ b/convolutional_neural_network.cpp
@@ -462,15 +462,15 @@ class Flatten : public Layer {
 
 class Dense : public Layer {
  public:
-  int num_in;
   int num_out;
+  int num_in;
 
   vector<vector<vector<double>>> weights;
   vector<double> biases;
 
-  Dense(int num_in, int num_out) {
-    this->num_in = num_in;
+  Dense(int num_out, int num_in) {
     this->num_out = num_out;
+    this->num_in = num_in;
 
     // Initialize weights with all values zero, then set all weights to a random value
     this->weights = vector<vector<vector<double>>>(num_out, vector<vector<double>>(num_in, vector<double>(1, 0)));
@@ -503,7 +503,7 @@ class Dense : public Layer {
   void static h_test() {
     vector<vector<vector<double>>> a{{{1}}, {{2}}, {{3}}};  // e.g. a[0] = {{1}};
 
-    Dense d = Dense(3, 5);
+    Dense d = Dense(5, 3);
     d.weights = {{{1}, {0}, {0}}, {{0}, {1}, {0}}, {{0}, {0}, {1}}, {{0}, {0}, {0}}, {{0}, {0}, {0}}};
     d.biases = {0, 0, 0, 0, 0};
 
@@ -517,7 +517,7 @@ class Dense : public Layer {
 
     vector<vector<vector<double>>> a2{{{1}}, {{2}}, {{3}}};
 
-    Dense d2 = Dense(3, 5);
+    Dense d2 = Dense(5, 3);
     d2.weights = {{{1}, {1}, {0}}, {{0}, {1}, {3}}, {{0}, {0}, {1}}, {{1}, {0}, {0}}, {{0}, {2}, {0}}};
     d2.biases = {0, 0, 0, 0, 0};
 
@@ -531,7 +531,7 @@ class Dense : public Layer {
 
     vector<vector<vector<double>>> a3{{{1}}, {{2}}, {{3}}};
 
-    Dense d3 = Dense(3, 5);
+    Dense d3 = Dense(5, 3);
     d3.weights = {{{1}, {1}, {0}}, {{0}, {1}, {3}}, {{0}, {0}, {1}}, {{1}, {0}, {0}}, {{0}, {2}, {0}}};
     d3.biases = {1, 1, 1, 2, -1};
 
@@ -730,7 +730,7 @@ class ConvNet {
 
   void static h_test_1(vector<vector<vector<vector<double>>>> X, int Y[100]) {
     Flatten flatten = Flatten();
-    Dense dense = Dense(4, 2);
+    Dense dense = Dense(2, 4);
     Sigmoid sigmoid = Sigmoid();
     ConvNet model = ConvNet(vector<Layer*>{&flatten, &dense, &sigmoid});
     // Do a forward pass with the first "image"
@@ -774,7 +774,7 @@ class ConvNet {
     Flatten flatten = Flatten();
     Dense dense1 = Dense(4, 4);
     Sigmoid sigmoid1 = Sigmoid();
-    Dense dense2 = Dense(4, 2);
+    Dense dense2 = Dense(2, 4);
     Sigmoid sigmoid2 = Sigmoid();
     ConvNet model = ConvNet(vector<Layer*>{&flatten, &dense1, &sigmoid1, &dense2, &sigmoid2});
     // Do a forward pass with the first "image"
@@ -821,7 +821,7 @@ class ConvNet {
     // MaxPool pool = MaxPool(2);
     // Relu relu = Relu();
     // Flatten flatten = Flatten();
-    // Dense dense = Dense(338, 10);
+    // Dense dense = Dense(10, 338);
     // Sigmoid sigmoid = Sigmoid();
     // ConvNet model = ConvNet(vector<Layer*>{&conv, &pool, &relu, &flatten, &dense, &sigmoid});
     // // Do a forward pass with the first "image"

--- a/convolutional_neural_network.cpp
+++ b/convolutional_neural_network.cpp
@@ -508,7 +508,7 @@ class Dense : public Layer {
     d.biases = {0, 0, 0, 0, 0};
 
     vector<vector<vector<double>>> output = d.h(a);
-    vector<vector<vector<double>>> expected_output = {{{1}}, {{2}}, {{3}}, {{0}}, {{0}}, {{0}}};
+    vector<vector<vector<double>>> expected_output = {{{1}}, {{2}}, {{3}}, {{0}}, {{0}}};
     for (int i = 0; i < output.size(); i++) {
       if (output[i][0][0] != expected_output[i][0][0]) {
         throw(string) "Test failed! " + (string) __FUNCTION__;
@@ -522,9 +522,24 @@ class Dense : public Layer {
     d2.biases = {0, 0, 0, 0, 0};
 
     vector<vector<vector<double>>> output2 = d2.h(a2);
-    vector<vector<vector<double>>> expected_output2 = {{{3}}, {{11}}, {{3}}, {{1}}, {{4}}, {{0}}};
+    vector<vector<vector<double>>> expected_output2 = {{{3}}, {{11}}, {{3}}, {{1}}, {{4}}};
     for (int i = 0; i < output2.size(); i++) {
       if (output2[i][0][0] != expected_output2[i][0][0]) {
+        throw(string) "Test failed! " + (string) __FUNCTION__;
+      }
+    }
+
+    vector<vector<vector<double>>> a3{{{1}}, {{2}}, {{3}}};
+
+    Dense d3 = Dense(3, 5);
+    d3.weights = {{{1}, {1}, {0}}, {{0}, {1}, {3}}, {{0}, {0}, {1}}, {{1}, {0}, {0}}, {{0}, {2}, {0}}};
+    d3.biases = {1, 1, 1, 2, -1};
+
+    vector<vector<vector<double>>> output3 = d3.h(a3);
+    vector<vector<vector<double>>> expected_output3 = {{{4}}, {{12}}, {{4}}, {{3}}, {{3}}};
+    for (int i = 0; i < output2.size(); i++) {
+      cout << output3[i][0][0] << endl;
+      if (output3[i][0][0] != expected_output3[i][0][0]) {
         throw(string) "Test failed! " + (string) __FUNCTION__;
       }
     }

--- a/convolutional_neural_network.cpp
+++ b/convolutional_neural_network.cpp
@@ -621,7 +621,7 @@ class ConvNet {
     return acc;
   }
 
-  vector<tuple<vector<vector<double>>, vector<double>>> _calc_dLoss_dParam(int y) {
+  vector<tuple<vector<vector<vector<double>>>, vector<double>>> _calc_dLoss_dParam(int y) {
     /*
     Return data type:
     For every layer, we need a vector
@@ -636,7 +636,7 @@ class ConvNet {
     vector<double> y_vector(10, 0);
     y_vector[y] = 1;
 
-    vector<tuple<vector<vector<double>>, vector<double>>> dParam_per_layer;
+    vector<tuple<vector<vector<vector<double>>>, vector<double>>> dParam_per_layer;
 
     for (int L = layers.size() - 1; L >= 0; L--) {
       bool is_last_output_box = false;
@@ -682,13 +682,13 @@ class ConvNet {
         ...
         */
 
-        vector<vector<double>> dW(dense->num_out, vector<double>(dense->num_in, 0));
+        vector<vector<vector<double>>> dW(dense->num_out, vector<vector<double>>(dense->num_in, vector<double>(1,0)));
         if (L == layers.size() - 2) {
           for (int i = 0; i < dense->num_out; i++) {
             for (int j = 0; j < dense->num_in; j++) {
-              dW[i][j] = a[L - 1][j][0][0];
-              dW[i][j] *= da_L_dz_L_per_layer[L][i][0][0];
-              dW[i][j] *= (a[L + 1][i][0][0] - y_vector[i]);
+              dW[i][j][0] = a[L - 1][j][0][0];
+              dW[i][j][0] *= da_L_dz_L_per_layer[L][i][0][0];
+              dW[i][j][0] *= (a[L + 1][i][0][0] - y_vector[i]);
             }
           }
         } else {  // runs when L = layers.size() - 4
@@ -700,8 +700,8 @@ class ConvNet {
                   */
           for (int i = 0; i < dense->num_out; i++) {
             for (int j = 0; j < dense->num_in; j++) {
-              dW[i][j] = a[L - 1][j][0][0];
-              dW[i][j] *= da_L_dz_L_per_layer[L][i][0][0];
+              dW[i][j][0] = a[L - 1][j][0][0];
+              dW[i][j][0] *= da_L_dz_L_per_layer[L][i][0][0];
 
               double sum = 0;
 
@@ -714,14 +714,14 @@ class ConvNet {
 
                 sum += part_sum;
               }
-              dW[i][j] *= sum;
+              dW[i][j][0] *= sum;
             }
           }
         }
 
         vector<double> dbiases(dense->num_out, 0);
 
-        tuple<vector<vector<double>>, vector<double>> dW_tuple = make_tuple(dW, dbiases);
+        tuple<vector<vector<vector<double>>>, vector<double>> dW_tuple = make_tuple(dW, dbiases);
         dParam_per_layer.push_back(dW_tuple);
       }
     }
@@ -741,7 +741,7 @@ class ConvNet {
       throw(string) "Test failed! " + (string) __FUNCTION__;
     }
 
-    vector<tuple<vector<vector<double>>, vector<double>>> dParam_per_layer = model._calc_dLoss_dParam(Y[0]);
+    vector<tuple<vector<vector<vector<double>>>, vector<double>>> dParam_per_layer = model._calc_dLoss_dParam(Y[0]);
     // (L(W+h) - L(W-h))/(2*h)
 
     for (int i = 0; i < dense.num_out; i++) {
@@ -749,7 +749,7 @@ class ConvNet {
         if (!(i == 0 && j == 0) && (rand() % 100) < 30) {
           continue;
         } else {
-          tuple<vector<vector<double>>, vector<double>> dParam = dParam_per_layer[0];
+          tuple<vector<vector<vector<double>>>, vector<double>> dParam = dParam_per_layer[0];
           double epsilon{0.001};
 
           // Might be better to loop over descreasing values of epsilon
@@ -760,9 +760,9 @@ class ConvNet {
           double loss2 = model.Loss(X[0], Y[0]);
 
           double num_dLoss_dWs = (loss1 - loss2) / (2 * epsilon);
-          cout << get<0>(dParam)[i][j] << endl;
+          cout << get<0>(dParam)[i][j][0] << endl;
           cout << num_dLoss_dWs << endl;
-          cout << "Difference in derivatives: " << num_dLoss_dWs - get<0>(dParam)[i][j] << endl;
+          cout << "Difference in derivatives: " << num_dLoss_dWs - get<0>(dParam)[i][j][0] << endl;
 
           dense.weights[i][j][0] += epsilon;
         }
@@ -785,7 +785,7 @@ class ConvNet {
       throw(string) "Test failed! " + (string) __FUNCTION__;
     }
 
-    vector<tuple<vector<vector<double>>, vector<double>>> dParam_per_layer = model._calc_dLoss_dParam(Y[0]);
+    vector<tuple<vector<vector<vector<double>>>, vector<double>>> dParam_per_layer = model._calc_dLoss_dParam(Y[0]);
     // (L(W+h) - L(W-h))/(2*h)
 
     for (int i = 0; i < dense1.num_out; i++) {
@@ -793,7 +793,7 @@ class ConvNet {
         if (!(i == 0 && j == 0) && (rand() % 100) < 30) {
           continue;
         } else {
-          tuple<vector<vector<double>>, vector<double>> dParam = dParam_per_layer[1];
+          tuple<vector<vector<vector<double>>>, vector<double>> dParam = dParam_per_layer[1];
           double epsilon{.001};
 
           // Might be better to loop over descreasing values of epsilon
@@ -804,9 +804,9 @@ class ConvNet {
           double loss2 = model.Loss(X[0], Y[0]);
 
           double num_dLoss_dWs = (loss1 - loss2) / (2 * epsilon);
-          cout << get<0>(dParam)[i][j] << endl;
+          cout << get<0>(dParam)[i][j][0] << endl;
           cout << num_dLoss_dWs << endl;
-          cout << "Difference in derivatives: " << num_dLoss_dWs - get<0>(dParam)[i][j] << endl;
+          cout << "Difference in derivatives: " << num_dLoss_dWs - get<0>(dParam)[i][j][0] << endl;
 
           dense1.weights[i][j][0] += epsilon;
         }


### PR DESCRIPTION
So I added a function that initializes dW to a flat tensor (last index is always 0) with random numbers

Changed Dense weights from vector<vector<double>> to vector<vector<vector<double>>> and fixed things that are affected
Did the same thing with dW

Changed the order of the parameters for Dense() because we had it backwards. It should be num rows by num columns so it should be num_out by num_in. 

Added a test for the biases. 